### PR TITLE
Fix docs cross-link paths

### DIFF
--- a/docs/architecture/components/task_execution_service/schemas/task_definitions.md
+++ b/docs/architecture/components/task_execution_service/schemas/task_definitions.md
@@ -460,6 +460,6 @@ For task definitions, consider these performance optimizations:
 ## Related Documentation
 
 * [Task Instances](./task_instances.md) - Documentation for task instances
-* [Workflow Definitions](./workflow_definitions.md) - Documentation for workflow definitions
-* [Workflow Instances](./workflow_instances.md) - Documentation for workflow instances
-* [UI Components](./ui_components.md) - Documentation for UI components
+* [Workflow Definitions](../../workflow_orchestrator_service/schemas/workflow_definitions.md) - Documentation for workflow definitions
+* [Workflow Instances](../../workflow_orchestrator_service/schemas/workflow_instances.md) - Documentation for workflow instances
+* [UI Components](../../web_application_service/schemas/ui_components.md) - Documentation for UI components

--- a/docs/architecture/components/task_execution_service/schemas/task_instances.md
+++ b/docs/architecture/components/task_execution_service/schemas/task_instances.md
@@ -352,8 +352,8 @@ For task instances, consider these performance optimizations:
 ## Related Documentation
 
 * [Task Definitions](./task_definitions.md) - Documentation for task definitions
-* [Workflow Instances](./workflow_instances.md) - Documentation for workflow instances
-* [Workflow Definitions](./workflow_definitions.md) - Documentation for workflow definitions
-* [Event Definitions](./event_definitions.md) - Documentation for event definitions
+* [Workflow Instances](../../workflow_orchestrator_service/schemas/workflow_instances.md) - Documentation for workflow instances
+* [Workflow Definitions](../../workflow_orchestrator_service/schemas/workflow_definitions.md) - Documentation for workflow definitions
+* [Event Definitions](../../event_processing_service/schemas/event_definitions.md) - Documentation for event definitions
 
 


### PR DESCRIPTION
## Summary
- fix incorrect schema links in task execution service docs

## Testing
- `git status --short`